### PR TITLE
Fixed compilation error in test

### DIFF
--- a/test/pyroenc_test.cpp
+++ b/test/pyroenc_test.cpp
@@ -100,7 +100,7 @@ int main(int argc, char *argv[])
 	auto img = dev.create_image(image_info);
 
 	FrameInfo frame = {};
-	frame.view = img->get_view().get_view();
+	frame.view = img->get_view().get_view().view;
 	frame.width = img->get_width();
 	frame.height = img->get_height();
 


### PR DESCRIPTION
I fixed a simple compilation error in the sample program. I pulled Granite by running the .sh file, I compiled everything with CMake and then I got the compilation error in  `test/pyroenc_test.cpp`.

Hope it helps.